### PR TITLE
Add some functions, fix some stuff

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,12 @@ macro_rules! define {
 define!(FALSE: c_int, 0);
 define!(TRUE: c_int, 1);
 
-define!(PFD_TYPE_RGBA, 0);
-define!(PFD_TYPE_COLORINDEX, 1);
+define!(PFD_TYPE_RGBA: BYTE, 0);
+define!(PFD_TYPE_COLORINDEX: BYTE, 1);
 
-define!(PFD_MAIN_PLANE, 0);
-define!(PFD_OVERLAY_PLANE, 1);
-define!(PFD_UNDERLAY_PLANE: c_int, -1);
+define!(PFD_MAIN_PLANE: BYTE, 0);
+define!(PFD_OVERLAY_PLANE: BYTE, 1);
+define!(PFD_UNDERLAY_PLANE: BYTE, 255);
 
 define!(PFD_DOUBLEBUFFER, 0x00000001);
 define!(PFD_STEREO, 0x00000002);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,15 +31,15 @@ macro_rules! define {
   };
 }
 
-define!(FALSE: c_int, 0);
-define!(TRUE: c_int, 1);
+define!(FALSE, 0);
+define!(TRUE, 1);
 
-define!(PFD_TYPE_RGBA: BYTE, 0);
-define!(PFD_TYPE_COLORINDEX: BYTE, 1);
+define!(PFD_TYPE_RGBA, 0);
+define!(PFD_TYPE_COLORINDEX, 1);
 
-define!(PFD_MAIN_PLANE: BYTE, 0);
-define!(PFD_OVERLAY_PLANE: BYTE, 1);
-define!(PFD_UNDERLAY_PLANE: BYTE, 255);
+define!(PFD_MAIN_PLANE, 0);
+define!(PFD_OVERLAY_PLANE, 1);
+define!(PFD_UNDERLAY_PLANE: c_int, -1);
 
 define!(PFD_DOUBLEBUFFER, 0x00000001);
 define!(PFD_STEREO, 0x00000002);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@ macro_rules! define {
   };
 }
 
-define!(FALSE, 0);
-define!(TRUE, 1);
+define!(FALSE: c_int, 0);
+define!(TRUE: c_int, 1);
 
 define!(PFD_TYPE_RGBA, 0);
 define!(PFD_TYPE_COLORINDEX, 1);
@@ -630,7 +630,7 @@ macro_rules! c_struct {
     #[cfg_attr(feature = "struct_eq", derive(PartialEq, Eq))]
     #[cfg_attr(feature = "struct_hash", derive(Hash))]
     pub struct $name {
-      $($field : $field_type),*
+      pub $($field : $field_type),*
     }
     impl Copy for $name {}
     impl Clone for $name { fn clone(&self) -> Self { *self } }
@@ -715,6 +715,9 @@ extern "system" {
   /// [`LoadLibraryA`](https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibrarya)
   pub fn LoadLibraryA(lpLibFileName: LPCSTR) -> HMODULE;
 
+  /// [`GetProcAddress`](https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getprocaddress)
+  pub fn GetProcAddress(hModule: HMODULE, lpProcName: LPCSTR) -> FARPROC;
+
   /// [`GetLastError`](https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror)
   pub fn GetLastError() -> DWORD;
 }
@@ -745,6 +748,11 @@ extern "system" {
   pub fn SetPixelFormat(
     hdc: HDC, format: c_int, ppfd: *const PIXELFORMATDESCRIPTOR,
   ) -> BOOL;
+
+  /// [`DescribePixelFormat`](https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-describepixelformat)
+  pub fn DescribePixelFormat(
+    hdc: HDC, iPixelFormat: c_int, nBytes: UINT, ppfd: *mut PIXELFORMATDESCRIPTOR,
+  ) -> c_int;
 
   /// [`SwapBuffers`](https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-swapbuffers)
   pub fn SwapBuffers(arg1: HDC) -> BOOL;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -630,7 +630,7 @@ macro_rules! c_struct {
     #[cfg_attr(feature = "struct_eq", derive(PartialEq, Eq))]
     #[cfg_attr(feature = "struct_hash", derive(Hash))]
     pub struct $name {
-      pub $($field : $field_type),*
+      $(pub $field : $field_type),*
     }
     impl Copy for $name {}
     impl Clone for $name { fn clone(&self) -> Self { *self } }

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,6 +27,8 @@ pub type c_ulonglong = u64;
 pub type c_float = f32;
 pub type c_double = f64;
 
+pub type FARPROC = *mut c_void;
+pub type NEARPROC = *mut c_void;
 pub type PROC = *mut c_void;
 
 typedef!(*mut c_void, HANDLE);


### PR DESCRIPTION
- `BOOL` should be a typedef for `c_int`
- `PFD_TYPE_RGBA`, `PFG_TYPE_COLORINDEX`, `PFD_MAIN_PLANE`, `PFD_OVERLAY_PLANE`, and `PFD_UNDERLAY_PLANE` should be `BYTE`
- `c_struct!` should generate structs with public fields
- Add the following functions:
    - `GetProcAddress`
    - `DescribePixelFormat`
- Add the following types:
    - `FARPROC`
    - `NEARPROC`